### PR TITLE
No listings found message should contain add listing link #408

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -11,6 +11,8 @@ Themify ultra theme has JS conflict on admin add listing page - FIXED
 Details page now adds the default id as a body class - ADDED
 Pending posts count numbers will now show next to the CPT admin menu item - ADDED
 Email settings subject and body placeholder text - ADDED
+No listings found message should contain add listing link - ADDED
+
 
 v2.0.0.48
 Customify theme page layout compatibility settings added - ADDED

--- a/includes/class-geodir-user.php
+++ b/includes/class-geodir-user.php
@@ -400,7 +400,7 @@ class GeoDir_User {
 
 		$post_types = geodir_get_posttypes( 'object' );
 
-		$addlisting_links = $output!=='select' ? array() : '';
+		$addlisting_links = $output=='array' ? array() : '';
 		foreach ( $post_types as $key => $postobj ) {
 			
 			if ( ! isset( $postobj->disable_frontend_add ) || $postobj->disable_frontend_add == '0' ) {
@@ -425,8 +425,8 @@ class GeoDir_User {
 					$add_link = apply_filters( 'geodir_dashboard_link_add_listing', $add_link, $key, get_current_user_id() );
 					$name     = apply_filters( 'geodir_dashboard_label_add_listing', $name, $key, get_current_user_id() );
 
-					if( $output === $key ){
-						$addlisting_links[ $key ] = array('url' => $add_link,'text'=>__( geodir_utf8_ucfirst( $name ), 'geodirectory' ));
+					if($output == 'array'){
+						$addlisting_links[$key] = array('url' => $add_link,'text'=>__( geodir_utf8_ucfirst( $name ), 'geodirectory' ));
 					}else{
 						$addlisting_links .= '<option ' . $selected . ' value="' . $add_link . '">' . __( geodir_utf8_ucfirst( $name ), 'geodirectory' ) . '</option>';
 					}
@@ -436,8 +436,8 @@ class GeoDir_User {
 
 		}
 
-		if( is_array( $addlisting_links ) && !empty( $addlisting_links[ $key ] ) ){
-			return $addlisting_links[ $key ];
+		if($output == 'array'){
+			return $addlisting_links;
 		}
 		elseif ( $addlisting_links != '' ) { ?>
 

--- a/includes/class-geodir-user.php
+++ b/includes/class-geodir-user.php
@@ -400,7 +400,7 @@ class GeoDir_User {
 
 		$post_types = geodir_get_posttypes( 'object' );
 
-		$addlisting_links = $output=='array' ? array() : '';
+		$addlisting_links = $output!=='select' ? array() : '';
 		foreach ( $post_types as $key => $postobj ) {
 			
 			if ( ! isset( $postobj->disable_frontend_add ) || $postobj->disable_frontend_add == '0' ) {
@@ -425,8 +425,8 @@ class GeoDir_User {
 					$add_link = apply_filters( 'geodir_dashboard_link_add_listing', $add_link, $key, get_current_user_id() );
 					$name     = apply_filters( 'geodir_dashboard_label_add_listing', $name, $key, get_current_user_id() );
 
-					if($output == 'array'){
-						$addlisting_links[] = array('url' => $add_link,'text'=>__( geodir_utf8_ucfirst( $name ), 'geodirectory' ));
+					if( $output === $key ){
+						$addlisting_links[ $key ] = array('url' => $add_link,'text'=>__( geodir_utf8_ucfirst( $name ), 'geodirectory' ));
 					}else{
 						$addlisting_links .= '<option ' . $selected . ' value="' . $add_link . '">' . __( geodir_utf8_ucfirst( $name ), 'geodirectory' ) . '</option>';
 					}
@@ -436,8 +436,8 @@ class GeoDir_User {
 
 		}
 
-		if($output == 'array'){
-			return $addlisting_links;
+		if( is_array( $addlisting_links ) && !empty( $addlisting_links[ $key ] ) ){
+			return $addlisting_links[ $key ];
 		}
 		elseif ( $addlisting_links != '' ) { ?>
 

--- a/templates/loop/no-listings-found.php
+++ b/templates/loop/no-listings-found.php
@@ -6,6 +6,15 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
-
+$show_add_listing = GeoDir_User::show_add_listings('array');
 ?>
-<p class="geodir-info"><?php _e( 'No listings were found matching your selection.', 'geodirectory' ); ?></p>
+<p class="geodir-info">
+    <?php
+
+    if( isset( $show_add_listing[0]['url'] ) && !empty( $show_add_listing[0]['url'] )){
+        printf( __( "No listings were found matching your selection, <a href='%s'>Add Listing</a>.", 'geodirectory' ), $show_add_listing[0]['url'] );
+    } else{
+	    _e( "No listings were found matching your selection.", 'geodirectory' );
+    }
+    ?>
+</p>

--- a/templates/loop/no-listings-found.php
+++ b/templates/loop/no-listings-found.php
@@ -6,13 +6,20 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
-$show_add_listing = GeoDir_User::show_add_listings('gd_place');
 ?>
 <p class="geodir-info">
     <?php
+    $show_add_listing = GeoDir_User::show_add_listings('array');
+    $current_pt = geodir_get_current_posttype();
+    $add_listing_link = array( 'url' => '' );
+    if( isset($show_add_listing[$current_pt])){
+	    $add_listing_link = $show_add_listing[$current_pt];
+    }else{
+	    $add_listing_link = reset( $show_add_listing );
+    }
 
-    if( isset( $show_add_listing['url'] ) && !empty( $show_add_listing['url'] )){
-        printf( __( "No listings were found matching your selection. Something missing? Why not <a href='%s'>add a listing?</a>.", 'geodirectory' ), $show_add_listing['url'] );
+    if( isset( $add_listing_link['url'] ) && !empty( $add_listing_link['url'] )){
+        printf( __( "No listings were found matching your selection. Something missing? Why not <a href='%s'>add a listing?</a>.", 'geodirectory' ), $add_listing_link['url'] );
     } else{
 	    _e( "No listings were found matching your selection.", 'geodirectory' );
     }

--- a/templates/loop/no-listings-found.php
+++ b/templates/loop/no-listings-found.php
@@ -6,13 +6,13 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
-$show_add_listing = GeoDir_User::show_add_listings('array');
+$show_add_listing = GeoDir_User::show_add_listings('gd_place');
 ?>
 <p class="geodir-info">
     <?php
 
-    if( isset( $show_add_listing[0]['url'] ) && !empty( $show_add_listing[0]['url'] )){
-        printf( __( "No listings were found matching your selection, <a href='%s'>Add Listing</a>.", 'geodirectory' ), $show_add_listing[0]['url'] );
+    if( isset( $show_add_listing['url'] ) && !empty( $show_add_listing['url'] )){
+        printf( __( "No listings were found matching your selection. Something missing? Why not <a href='%s'>add a listing?</a>.", 'geodirectory' ), $show_add_listing['url'] );
     } else{
 	    _e( "No listings were found matching your selection.", 'geodirectory' );
     }


### PR DESCRIPTION
Added code for If add listing enabled and a cat or search has no listings then the no listings message should have a link to the add listing page.