### PR TITLE
"Unicon" theme compatibility for gd pages - ADDED

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,6 +1,7 @@
 = 2.0.0.59 =
 * GD Listings widget title not working with pagination - FIXED
 * Some fields are not stripping slashes - FIXED
+* "Unicon" theme compatibility for gd pages - ADDED
 
 = 2.0.0.58 =
 * Sometimes distance value not showing on search page - FIXED

--- a/includes/class-geodir-compatibility.php
+++ b/includes/class-geodir-compatibility.php
@@ -406,6 +406,17 @@ class GeoDir_Compatibility {
 			}
 		}
 
+		// Unicon
+		if ( function_exists( 'minti_register_required_plugins' ) && strpos( $meta_key, 'minti_' ) === 0 ) {
+			$gen_keys[] = $meta_key;
+
+			// Archive page set page post.
+			if ( ! empty( $wp_query ) && ! empty( $wp_query->post->post_type ) && geodir_is_gd_post_type( get_post_type( $object_id ) ) && $wp_query->post->post_type == 'page' && ( geodir_is_page( 'single' ) || geodir_is_page( 'archive' ) || geodir_is_page( 'post_type' ) || geodir_is_page( 'search' ) ) ) {
+				$post = $wp_query->post;
+				$backup_post = $post;
+			}
+		}
+
 		if (
 			$meta_key
 			&& ( $meta_key[0] == "_" || in_array( $meta_key, $gen_keys ) )


### PR DESCRIPTION
See https://wpgeodirectory.com/support/topic/listing-url-prefix-no-longer-works/