### PR TITLE
Prevent users from using custom fields that match standard WP fields

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -1,5 +1,6 @@
 = 2.0.0.60 =
 * Polifill for CSS object-fit in browsers that don't support it - Added
+* Prevent saving custom fields found in array of standard fields - ADDED
 
 = 2.0.0.59 =
 * GD Listings widget title not working with pagination - FIXED

--- a/includes/admin/settings/class-geodir-settings-cpt-cf.php
+++ b/includes/admin/settings/class-geodir-settings-cpt-cf.php
@@ -1889,7 +1889,20 @@ if ( ! class_exists( 'GeoDir_Settings_Cpt_Cf', false ) ) :
 			$field = self::sanatize_custom_field($field);
 
 			//print_r($field);exit;
-			
+
+			//Ensure that field key/html var does not match standard wordpress columns
+			$wp_post_cols = $wpdb->get_col( "SHOW COLUMNS FROM `{$wpdb->posts}`" );
+			if( is_array( $wp_post_cols )){
+
+				//Ignore gd default fields
+				unset($wp_post_cols['post_title']);
+				unset($wp_post_cols['post_content']);
+
+				if(in_array( $field->htmlvar_name, $wp_post_cols )){
+					return new WP_Error( 'failed', __( "Field key name MUST NOT match a standard WordPress field, please use another key and re-save.", "geodirectory" ) );
+				}
+			}
+
 			// Check field exists.
 			$exists = self::field_exists($field);
 

--- a/includes/admin/settings/class-geodir-settings-cpt-cf.php
+++ b/includes/admin/settings/class-geodir-settings-cpt-cf.php
@@ -1891,16 +1891,31 @@ if ( ! class_exists( 'GeoDir_Settings_Cpt_Cf', false ) ) :
 			//print_r($field);exit;
 
 			//Ensure that field key/html var does not match standard wordpress columns
-			$wp_post_cols = $wpdb->get_col( "SHOW COLUMNS FROM `{$wpdb->posts}`" );
-			if( is_array( $wp_post_cols )){
-
-				//Ignore gd default fields
-				unset($wp_post_cols['post_title']);
-				unset($wp_post_cols['post_content']);
-
-				if(in_array( $field->htmlvar_name, $wp_post_cols )){
-					return new WP_Error( 'failed', __( "Field key name MUST NOT match a standard WordPress field, please use another key and re-save.", "geodirectory" ) );
-				}
+			$wp_post_cols = array(
+				'ID',
+				'post_author',
+				'post_date',
+				'post_date_gmt',
+				'post_excerpt',
+				'post_status',
+				'comment_status',
+				'ping_status',
+				'post_password',
+				'post_name',
+				'to_ping',
+				'pinged',
+				'post_modified',
+				'post_modified_gmt',
+				'post_content_filtered',
+				'post_parent',
+				'guid',
+				'menu_order',
+				'post_type',
+				'post_mime_type',
+				'comment_count',
+			);
+			if(in_array( $field->htmlvar_name, $wp_post_cols )){
+				return new WP_Error( 'failed', __( "Field key name MUST NOT match a standard WordPress field, please use another key and re-save.", "geodirectory" ) );
 			}
 
 			// Check field exists.


### PR DESCRIPTION
#765 Stop users from saving custom fields with the same names as standard WordPress post fields.