### PR TITLE
Add filter for changing listing url

### DIFF
--- a/includes/general-functions.php
+++ b/includes/general-functions.php
@@ -141,8 +141,8 @@ function geodir_get_addlisting_link( $post_type = '' ) {
 	if ( post_type_exists( $post_type ) && $check_pkg ) {
 
 		$add_listing_link = get_page_link( geodir_add_listing_page_id() );
-
-		return esc_url( add_query_arg( array( 'listing_type' => $post_type ), $add_listing_link ) );
+		$add_listing_link =  apply_filters( 'extend_addlisting_link', add_query_arg( array( 'listing_type' => $post_type ), $add_listing_link ) );
+		return esc_url($add_listing_link);
 	} else {
 		return get_bloginfo( 'url' );
 	}


### PR DESCRIPTION
Client request: 
https://wpgeodirectory.com/support/topic/adding-linked-post-without-searching-for-linked-listing/

Add listing page URL can be extended with
```
add_filter( 'extend_addlisting_link','extend_addlisting_link_callback', 10, 1);
function extend_addlisting_link_callback( $listing_link ){
   $listing_link = add_query_arg( array( 'linked_post' =>  123 ), $listing_link );
    return $listing_link;
}
```