### PR TITLE
Include post images in Rank Math sitemap - ADDED

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -17,6 +17,7 @@
 * Going away from edit listing page always shows popup warning about unsaved changes - FIXED
 * The7 theme compatibility for GD pages - FIXED
 * Ninja forms widget now has option to output the form direct, can be used in sidebar or in tab - ADDED
+* Include post images in Rank Math sitemap - ADDED
 
 = 2.0.0.65 =
 * Jarida theme compatibility for GD page sidebars - FIXED

--- a/includes/class-geodir-compatibility.php
+++ b/includes/class-geodir-compatibility.php
@@ -32,6 +32,7 @@ class GeoDir_Compatibility {
 		######################################################*/
 		// add setting to be able to disable Rank Math on GD pages
 		add_filter( 'geodir_seo_options', array( __CLASS__, 'rank_math_disable' ), 10 );
+		add_filter( 'rank_math/sitemap/urlimages', array( __CLASS__, 'rank_math_add_images_to_sitemap' ), 10, 2 );
 
 		/*######################################################
 		Disqus (comments system) :: If Disqus plugin is active, do some fixes to show on blogs but no on GD post types
@@ -790,6 +791,28 @@ class GeoDir_Compatibility {
 
 
 		return $options;
+	}
+
+	public static function rank_math_add_images_to_sitemap( $images, $id ){
+
+		$post_type = get_post_type( $id );
+
+		if(! geodir_is_gd_post_type( $post_type ) ) {
+			return $images;
+		}
+
+		$geodir_images = geodir_get_images( $id );
+
+		if( is_array( $geodir_images ) ) {
+			foreach( $geodir_images as $geodir_image ) {
+				$images[] = array(
+					'src'   => geodir_get_image_src( $geodir_image, 'original' ),
+					'title' => $geodir_image->title,
+				);
+			}
+		}
+
+		return $images;
 	}
 
 	public static function wpseo_disable( $options ) {


### PR DESCRIPTION
This includes post images in the sitemap. Detecting image alt and external links is done via js so there is nothing we can do from GD.

