### PR TITLE
Fixed business hours parsing when GMT offset is set to 0

### DIFF
--- a/includes/business-hours-functions.php
+++ b/includes/business-hours-functions.php
@@ -391,7 +391,7 @@ function geodir_schema_to_array( $schema ) {
 	if ( ! empty( $schema_array[1] ) ) {
 		$gmt_offset = str_replace(' ', '', $schema_array[1]);
 		$gmt_offset = str_replace(array('"UTC":"', '"', '[', ']'), '', $schema_array[1]);
-		$return['offset'] = ( ! empty( $gmt_offset ) ? $gmt_offset : geodir_gmt_offset() );
+		$return['offset'] = ( $gmt_offset == "0" || ! empty( $gmt_offset ) ? $gmt_offset : geodir_gmt_offset() );
 	}
 	
 	return $return;


### PR DESCRIPTION
Under specific circumstances, places located in London will appear closed even though they are open, because geodir_schema_to_array() incorrectly converts ["UTC":"0"] to the local GMT offset. Using empty to validate the value is insufficient since empty(0) is true.