### PR TITLE
Add fix for Translation of screen_id break GD dashboard functionality

### DIFF
--- a/change_log.txt
+++ b/change_log.txt
@@ -2,6 +2,7 @@
 * Category font awesome icons have extra fas class on output which break few icons – FIXED
 * Post badge widget shows excluded fields from package - FIELD
 * GD Archive map with elementor loop might not filter markers if map is before loop - FIXED
+* Translation of screen_id break GD dashboard functionality - FIXED
 
 = 2.0.0.90 =
 * Customize map popup template for the post type - ADDED

--- a/includes/admin/admin-functions.php
+++ b/includes/admin/admin-functions.php
@@ -18,11 +18,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return array
  */
 function geodir_get_screen_ids() {
-
-	$geodir_screen_id = sanitize_title( __( 'GeoDirectory', 'geodirectory' ) );
-
 	$screen_ids = array(
-		'toplevel_page_' . $geodir_screen_id,
+		'toplevel_page_geodirectory',
 		'geodirectory_page_gd-settings',
 		'geodirectory_page_gd-status',
 		'geodirectory_page_gd-addons',


### PR DESCRIPTION
GD screen_id has been translated which disturbs the functionality.  

<img width="985" alt="Screenshot 2020-04-23 at 8 41 28 PM" src="https://user-images.githubusercontent.com/24760592/80115817-d603f080-85a2-11ea-97fe-7d989a8ab07b.png">

<img width="453" alt="Screenshot 2020-04-23 at 8 32 37 PM" src="https://user-images.githubusercontent.com/24760592/80114793-9c7eb580-85a1-11ea-9af6-d00930af0002.png">
