### PR TITLE
Fix geodir_get_business_hours() extra variables for 24hours opening

### DIFF
--- a/includes/business-hours-functions.php
+++ b/includes/business-hours-functions.php
@@ -616,7 +616,7 @@ function geodir_get_business_hours( $value = '' ) {
 					$opens_time = strtotime( $opens );
 					$closes_time = strtotime( date_i18n( 'H:i:59', strtotime( $closes ) ) );
 					
-					if ( $is_today && $opens_time <= $time_int && $time_int <= $closes_time ) {
+					if ( $is_today && (($opens_time <= $time_int && $time_int <= $closes_time) || ($opens == '00:00' && $opens == $closes)) ) {
 						$is_open = 1;
 						$has_open = 1;
 					} else {


### PR DESCRIPTION
When a place set businees hours open all day the extra variables return by geodir_get_business_hours() function return place closed.
I updated the function to fix this and return the correct value for extra.has_open and extra.has_closed variables.