### PR TITLE
Adds filter to $taxonomy['rewrite']['with_front'] to allow prepending to slug.

### DIFF
--- a/includes/admin/settings/class-geodir-settings-cpt.php
+++ b/includes/admin/settings/class-geodir-settings-cpt.php
@@ -781,7 +781,7 @@ if ( ! class_exists( 'GeoDir_Settings_Cpt', false ) ) :
 			$output[$post_type]['show_in_nav_menus'] = true;
 			$output[$post_type]['rewrite'] = array(
 				'slug' => $slug,
-				'with_front' => false,
+				'with_front' => apply_filters( 'geodir_cpt_rewrite_front', false ),
 				'hierarchical' => true,
 				'feeds' => true
 			);

--- a/includes/class-geodir-post-types.php
+++ b/includes/class-geodir-post-types.php
@@ -147,7 +147,7 @@ class GeoDir_Post_types {
 				'query_var'       => true,
 				'rewrite'         => array(
 					'slug'         => $listing_slug,
-					'with_front'   => false,
+					'with_front'   => apply_filters( 'geodir_cpt_rewrite_front', false ),
 					'hierarchical' => true,
 					'feeds'        => true
 				),
@@ -200,7 +200,7 @@ class GeoDir_Post_types {
 			$gd_placetags['args'] = array(
 				'public' => true,
 				'hierarchical' => false,
-				'rewrite' => array('slug' => $listing_slug . '/tags', 'with_front' => false, 'hierarchical' => true),
+				'rewrite' => array('slug' => $listing_slug . '/tags', 'with_front' => apply_filters( 'geodir_cpt_rewrite_front', false ), 'hierarchical' => true),
 				'query_var' => true,
 
 				'labels' => array(
@@ -227,7 +227,7 @@ class GeoDir_Post_types {
 			$gd_placecategory['args'] = array(
 				'public' => true,
 				'hierarchical' => true,
-				'rewrite' => array('slug' => $listing_slug, 'with_front' => false, 'hierarchical' => true),
+				'rewrite' => array('slug' => $listing_slug, 'with_front' => apply_filters( 'geodir_cpt_rewrite_front', false ), 'hierarchical' => true),
 				'query_var' => true,
 				'labels' => array(
 					'name' => sprintf( __('%s Categories', 'geodirectory'), $singular_name ),

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -1018,7 +1018,7 @@ function geodir_tool_restore_cpt_from_taxonomies() {
             'query_var' => true,
             'rewrite' => array (
                 'slug' => $cpt['slug'],
-                'with_front' => false,
+                'with_front' => apply_filters( 'geodir_cpt_rewrite_front', false ),
                 'hierarchical' => true,
                 'feeds' => true,
             ),


### PR DESCRIPTION
This PR adds a filter `geodir_cpt_rewrite_front` to taxonomy creation (`$taxonomy['rewrite']['with_front']`).

This allows devs to prepend a parent url to geodirectory (e.g. `mysite.com/places` => `mysite.com/services/places`), instead of forcing devs to use geodirectory as a top-level link (not great for advanced sites with more than just GD going on) or create a geodirectory-specific subsite on that url (a workaround suggested by support). 

The change itself has *no other impact on the current code functionality*, and is intentionally simple so as to (hopefully) allow for immediate inclusion upstream. 

The PR _could_ be tweaked to include more advanced conditional generation (e.g. changing `apply_filters( 'geodir_cpt_rewrite_front', false )` to `apply_filters( 'geodir_cpt_rewrite_front', false, $listing_slug, ...$x )`), but a decision to include that is best left to the the project leads, and I don't want anything slowing down this PR 🤞.

PS: while I don't actually use the Custom Post Types addon, I see this filter being extremely useful there (so you can have `mysite.com/directory/hospitals` and `mysite.com/directory/eateries` instead of keeping them both top-level). Since there isn't a public repo for that plugin, I'm [attaching the changed file ](https://gist.github.com/justlevine/e2b78d910cb7240ece718234fd115268) to enable the filter there.
tl;dr `'with_front' => false,` on lines 195 and 229 become `apply_filters( "geodir_cpt_{$listing_slug}_rewrite_front", false ),`, letting developers filter per cpt (so they could theoretically have `mysite.com/directory/hospitals` and `mysite.com/directory/eateries`, but also `mysite.com/partners` and `mysite.com/about/find-a-branch`. 

## Usage examples
```php
// Change mysite.com/places => mysite.com/directory/places .
add_filter( 
    'geodir_cpt_rewrite_front,
    function ($front) {
        return 'directory';
    },
    10,
    1
);


