### PR TITLE
Business Hours don't render correctly when displayed in a geodir_post_meta list block

### DIFF
--- a/includes/widgets/class-geodir-widget-output-location.php
+++ b/includes/widgets/class-geodir-widget-output-location.php
@@ -134,7 +134,7 @@ class GeoDir_Widget_Output_Location extends WP_Super_Duper {
 
         if (!empty($args['location']) && $geodir_post_detail_fields ) {
 	        if($geodir_post_detail_fields && $design_style && $wrap_class){
-		        $geodir_post_detail_fields = str_replace("geodir_post_meta ","geodir_post_meta list-group-item list-group-item-action ".$inner_class,$geodir_post_detail_fields);
+		        $geodir_post_detail_fields = str_replace("geodir_post_meta ","geodir_post_meta list-group-item list-group-item-action ".$inner_class.' ',$geodir_post_detail_fields);
 	        }
             $output .= "<div class='$wrap_class d-block geodir-output-location geodir-output-location-".esc_attr($args['location'])."' style='$wrap_style' >";
             $output .= $geodir_post_detail_fields;


### PR DESCRIPTION
This missing space breaks a bunch of scenarios. For example Business Hours fields are rendered as:
`<div class="geodir_post_meta list-group-item px-2gd-bh-show-field  geodir-field-business_hours>`
instead of:
`<div class="geodir_post_meta list-group-item px-2 gd-bh-show-field  geodir-field-business_hours>`

This impacts code that looks up elements based on the `gd-bh-show-field` class, including ` geodir_refresh_business_hours()`.
