### PR TITLE
Fix for Fatal Error When Elementor is Not Installed in GeoDirectory v2.3.19+

### DIFF
--- a/includes/class-geodir-elementor.php
+++ b/includes/class-geodir-elementor.php
@@ -1303,9 +1303,16 @@ class GeoDir_Elementor {
 	 * @return object Elementor document.
 	 */
 	public static function get_elementor_document( $page_id ) {
-		$document = \Elementor\Plugin::$instance->documents->get( (int) $page_id );
-
-		return $document;
+		// Check if Elementor Plugin class exists to ensure compatibility
+		if ( class_exists( '\Elementor\Plugin' ) ) {
+			// If Elementor is available, get the document
+			$document = \Elementor\Plugin::$instance->documents->get( (int) $page_id );
+			return $document;
+		} else {
+			// Return null if Elementor is not active or installed
+			// This prevents errors and ensures graceful degradation
+			return null;
+		}
 	}
 
 	/**


### PR DESCRIPTION
**Description of the Change**
This pull request addresses the issue where a PHP fatal error occurs in GeoDirectory version 2.3.19 or higher when Elementor is not installed. The error is triggered in the `class-geodir-elementor.php` file.

**Approach**
The proposed change involves adding a conditional check to ensure the Elementor class exists before attempting to use it. This prevents the fatal error and allows GeoDirectory to function normally even when Elementor is not present.

**Code Changes**
Modified `get_elementor_document` function in `class-geodir-elementor.php`:
```php
public static function get_elementor_document( $page_id ) {
    // Check if Elementor Plugin class exists to ensure compatibility
    if ( class_exists( '\Elementor\Plugin' ) ) {
        // If Elementor is available, get the document
        $document = \Elementor\Plugin::$instance->documents->get( (int) $page_id );
        return $document;
    } else {
        // Return null if Elementor is not active or installed
        // This prevents errors and ensures graceful degradation
        return null;
    }
}
```
**Related Issue**
https://github.com/AyeCode/geodirectory/issues/2498