### PR TITLE
AJAX search with empty text don't show placeholder text for main search input - CHANGED

### DIFF
--- a/includes/class-geodir-frontend-scripts.php
+++ b/includes/class-geodir-frontend-scripts.php
@@ -205,6 +205,8 @@ class GeoDir_Frontend_Scripts {
 								});
 							}
 						}
+					} else {
+						s = ''; /* Keep placeholder for AJAX search. */
 					}
 					<?php } ?>
 

--- a/readme.txt
+++ b/readme.txt
@@ -319,6 +319,9 @@ We don't offer free trials, but we have a 30-day money-back guarantee if you are
 
 __WARNING: GDv2 is a significant update over GDv1 and may require manual work, such as adding widgets to sidebars to recreate your current layout. As always, we recommend trying this on a staging site first. [Learn more](https://docs.wpgeodirectory.com/article/260-upgrading-from-gdv1-to-gdv2)__
 
+= GeoDirectory v2.8.94 - TBD =
+* AJAX search with empty text don't show placeholder text for main search input - CHANGED
+
 = GeoDirectory v2.8.93 - 2024-12-19 =
 * MySQL error BLOB, TEXT, GEOMETRY or JSON column can't have a default value - FIXED
 * Google map street view pegman icon not visible - FIXED


### PR DESCRIPTION
Fixes #2759

It was added since early of GeoDirectory for some reason. I adjusted for AJAX search to keep placeholder.