### PR TITLE
Fix: apply Bootstrap sizing classes to select fields

### DIFF
--- a/includes/core-functions.php
+++ b/includes/core-functions.php
@@ -1101,7 +1101,10 @@ function geodir_search_form_post_type_input() {
 				echo "<div class='gd-search-input-wrapper gd-search-field-cpt $wrap_class' " . $attrs . ">";
 			}
 
-			$select_class = $design_style ? " form-control " . ( $aui_bs5 ? 'form-select' : 'custom-select' ) : '';
+			$select_class = $design_style ? " form-control " . ($aui_bs5 ? 'form-select' : 'custom-select') : '';
+			if ($design_style && !empty($geodir_search_widget_params['input_size'])) {
+				$select_class .= $aui_bs5 ? ' form-select-' . $geodir_search_widget_params['input_size'] : ' custom-select-' . $geodir_search_widget_params['input_size'] . ' form-control-' . $geodir_search_widget_params['input_size'];
+			}
 
 			echo $design_style ? '<div class="' . ( $aui_bs5 ? '' : 'form-group' ) . '">' : '';
 			echo $design_style ? '<label class="sr-only visually-hidden">'.__("Select search type","geodirectory").'</label>' : '';


### PR DESCRIPTION
This PR fixes a visual inconsistency in the GD > Search block where select fields (specifically the Post Type selector) were not scaling when the "Input size" setting was changed to "Large".

While other inputs in the search block correctly received sizing classes, select fields were missing the appropriate Bootstrap sizing classes.

**Testing Instructions:**
Navigate to the WordPress editor and add a GD > Search block.
In the block settings, change the Input size to Large.
View the search bar on the frontend/backend and verify that the Post Type dropdown matches the height and style of the search text input.