### PR TITLE
Select2 v4.x causes JS error on use of comma in tags field - FIXED

### DIFF
--- a/includes/custom-fields/input-functions-aui.php
+++ b/includes/custom-fields/input-functions-aui.php
@@ -2092,6 +2092,7 @@ function geodir_cfi_tags( $html, $cf ) {
 			// Disable new tags
 			if ( ! empty( $extra_fields['disable_new_tags'] ) ) {
 				$extra_attributes['data-tags'] = 'false';
+				$extra_attributes['data-token-separators'] = "";
 			}
 
 			// Enable spell check

--- a/readme.txt
+++ b/readme.txt
@@ -323,6 +323,7 @@ __WARNING: GDv2 is a significant update over GDv1 and may require manual work, s
 * Spectra block styles failed to load on listing preview page - FIXED
 * Added hyperlink to the email logo - ADDED
 * Options added to customize email logo width and height - ADDED
+* Select2 v4.x causes JS error on use of comma in tags field - FIXED
 
 = GeoDirectory v2.8.166 - 2026-07-01 =
 * Merge AUI 0.2.51 - CHANGED


### PR DESCRIPTION
Fixes #3054 