### PR TITLE
Fix unauthenticated SQL injection in single-review email check

### DIFF
--- a/includes/class-geodir-comments.php
+++ b/includes/class-geodir-comments.php
@@ -1246,15 +1246,18 @@ class GeoDir_Comments {
 			$where .= ' AND r.rating > 0';
 		}
 
+		$prepare = array( $post_id );
+
 		if ( ! empty( $user_id ) ) {
 			$where .= ' AND cmt.user_id = ' . (int) $user_id;
 		}
 
 		if ( ! empty( $author_email ) ) {
-			$where .= " AND cmt.comment_author_email = '" . $author_email . "'";
+			$where    .= ' AND cmt.comment_author_email = %s';
+			$prepare[] = $author_email;
 		}
 
-		$sql = $wpdb->prepare( 'SELECT COUNT(*) FROM ' . GEODIR_REVIEW_TABLE . " AS r JOIN {$wpdb->comments} AS cmt ON cmt.comment_ID = r.comment_id WHERE r.post_id = %d {$where}", array( $post_id ) );
+		$sql = $wpdb->prepare( 'SELECT COUNT(*) FROM ' . GEODIR_REVIEW_TABLE . " AS r JOIN {$wpdb->comments} AS cmt ON cmt.comment_ID = r.comment_id WHERE r.post_id = %d {$where}", $prepare );
 
 		$sql = apply_filters( 'geodir_count_user_post_reviews_sql', $sql, $post_id, $user_id, $author_email );
 

--- a/readme.txt
+++ b/readme.txt
@@ -328,6 +328,9 @@ Please include as much relevant information as possible and avoid publicly discl
 
 __WARNING: GDv2 is a significant update over GDv1 and may require manual work, such as adding widgets to sidebars to recreate your current layout. As always, we recommend trying this on a staging site first. [Learn more](https://wpgeodirectory.com/documentation/article/how-tos/upgrading-from-gdv1-to-gdv2/)__
 
+= GeoDirectory v2.8.175 - TBD =
+* Prevent SQL injection via review author email in single-review check – FIXED/SECURITY
+
 = GeoDirectory v2.8.174 - 2026-08-18 =
 * Added extra validation in REST auth requests – FIXED/SECURITY
 


### PR DESCRIPTION
count_user_post_reviews() concatenated the comment_author_email value straight into the query; passing it through wpdb::prepare() only bound post_id, so a crafted email POST parameter (sanitize_email keeps quotes) allowed boolean-based blind SQL injection.

Bind comment_author_email as a %s placeholder so prepare() escapes it.